### PR TITLE
fix: add netlify.toml file with correct redirect to address bug

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
# Pull Request

## Description
<!-- Brief description of what this PR does. -->
This PR adds netlify.toml file with correct redirect to address bug where trying to reach any link other than root would result in 404 error on Netlify.

## Type of change
<!-- Please check the options that are relevant. -->

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Data contribution/update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes made
<!--
- List the main changes made in this PR
- Be specific about what was added, modified, or removed
- Mention any new dependencies or configuration changes
-->
- Add `netlify.toml` file

## Data quality (for data contributions)

- [ ] Data follows the project's data standards
- [ ] Data includes proper source attribution
- [ ] Data is properly formatted (JSON/CSV structure)

## Screenshots (if applicable)
<!-- Add screenshots or GIFs to show UI changes. -->

## Related issues

Closes #12

## Additional notes
<!-- Any additional information that reviewers should know about this PR. -->
